### PR TITLE
remove server_name directive from nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       context: ./nginx
       args:
         NGINX_VERSION: ${NGINX_VERSION}
-        SERVER_NAME: ${DOMAIN}
     restart: always
     volumes:
       - code:/code

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,9 +1,6 @@
 ARG NGINX_VERSION
 FROM nginx:${NGINX_VERSION}-alpine
 
-COPY default.conf.template /etc/nginx/conf.d/default.conf
-
-ARG SERVER_NAME
-RUN sed -i "s/{{SERVER_NAME}}/${SERVER_NAME}/g" /etc/nginx/conf.d/default.conf
+COPY default.conf /etc/nginx/conf.d/default.conf
 
 WORKDIR /etc/nginx

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,4 @@
 server {
-  server_name  {{SERVER_NAME}};
   listen   80;
   # listen for ipv6
   listen   [::]:80 default ipv6only=on;


### PR DESCRIPTION
No need to define the server_name because nginx is not publicly accessible (servers name are managed on top of it (nginx-proxy))